### PR TITLE
Fixes the authorization switch for refunds and shipping

### DIFF
--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -79,7 +79,8 @@ module ActiveMerchant #:nodoc:
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          raise Error, REFUND_ERROR_MESSAGE
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          # raise Error, REFUND_ERROR_MESSAGE
         end
       end
 
@@ -91,7 +92,8 @@ module ActiveMerchant #:nodoc:
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          raise Error, CAPTURE_ERROR_MESSAGE
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          # raise Error, CAPTURE_ERROR_MESSAGE
         end
       end
 

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -75,11 +75,11 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case reference
         when /1$/
-          raise Error, REFUND_ERROR_MESSAGE
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          raise Error, REFUND_ERROR_MESSAGE
         end
       end
 
@@ -87,11 +87,11 @@ module ActiveMerchant #:nodoc:
         money = amount(money)
         case reference
         when /1$/
-          raise Error, CAPTURE_ERROR_MESSAGE
+          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
+          raise Error, CAPTURE_ERROR_MESSAGE
         end
       end
 

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -27,7 +27,7 @@ module ActiveMerchant #:nodoc:
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
+          raise Error, ERROR_MESSAGE
         end
       end
 
@@ -80,8 +80,7 @@ module ActiveMerchant #:nodoc:
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-          # raise Error, REFUND_ERROR_MESSAGE
+          raise Error, REFUND_ERROR_MESSAGE
         end
       end
 
@@ -93,20 +92,18 @@ module ActiveMerchant #:nodoc:
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:paid_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:paid_amount => money}, :test => true)
-          # raise Error, CAPTURE_ERROR_MESSAGE
+          raise Error, CAPTURE_ERROR_MESSAGE
         end
       end
 
       def void(reference, options = {})
         case reference
         when /1$/
-          #raise Error, VOID_ERROR_MESSAGE
           Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorization => reference, :error => FAILURE_MESSAGE }, :test => true)
         else
-          Response.new(true, SUCCESS_MESSAGE, {:authorization => reference}, :test => true)
+          raise Error, VOID_ERROR_MESSAGE
         end
       end
 

--- a/lib/active_merchant/billing/gateways/bogus.rb
+++ b/lib/active_merchant/billing/gateways/bogus.rb
@@ -20,13 +20,14 @@ module ActiveMerchant #:nodoc:
 
       def authorize(money, credit_card_or_reference, options = {})
         money = amount(money)
+
         case normalize(credit_card_or_reference)
         when /1$/
           Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         when /2$/
           Response.new(false, FAILURE_MESSAGE, {:authorized_amount => money, :error => FAILURE_MESSAGE }, :test => true)
         else
-          raise Error, ERROR_MESSAGE
+          Response.new(true, SUCCESS_MESSAGE, {:authorized_amount => money}, :test => true, :authorization => AUTHORIZATION )
         end
       end
 


### PR DESCRIPTION
Changes the order of switch statements for #refund and #ship. Seems like it was set to deny the capture with the default AUTHORIZATION code
