### PR TITLE
fix captures for currencies that do not use fractions for sage pay gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/sage_pay.rb
+++ b/lib/active_merchant/billing/gateways/sage_pay.rb
@@ -159,7 +159,8 @@ module ActiveMerchant #:nodoc:
 
       # doesn't actually use the currency -- dodgy!
       def add_release_amount(post, money, options)
-        add_pair(post, :ReleaseAmount, amount(money), :required => true)
+        currency = options[:currency] || currency(money)
+        add_pair(post, :ReleaseAmount, localized_amount(money, currency), :required => true)
       end
 
       def add_customer_data(post, options)


### PR DESCRIPTION
- was breaking in LJ for JPY currency

```
3006 : The fractional part of the Amount is invalid for the specified currency.
```
