### PR TITLE
update authorize.net API urls to new Akamai SureRoute urls

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -29,10 +29,10 @@ module ActiveMerchant #:nodoc:
       class_attribute :arb_test_url, :arb_live_url
 
       self.test_url = "https://test.authorize.net/gateway/transact.dll"
-      self.live_url = "https://secure.authorize.net/gateway/transact.dll"
+      self.live_url = "https://secure2.authorize.net/gateway/transact.dll"
 
       self.arb_test_url = 'https://apitest.authorize.net/xml/v1/request.api'
-      self.arb_live_url = 'https://api.authorize.net/xml/v1/request.api'
+      self.arb_live_url = 'https://api2.authorize.net/xml/v1/request.api'
 
       class_attribute :duplicate_window
 
@@ -91,7 +91,7 @@ module ActiveMerchant #:nodoc:
       def authorize(money, paysource, options = {})
 
         if paysource.is_a?(String)
-          # This is a Sellect fix to allow the same authorize 
+          # This is a Sellect fix to allow the same authorize
           # method to be called from the gateway, matches other
           # gateway behaviors
           cim = AuthorizeNetCimGateway.new(@options)


### PR DESCRIPTION
**Authorize.net** is making updates to their API urls to use Akamai SureRoute as described [here](http://app.payment.authorize.net/e/es.aspx?s=986383348&e=1178287&elq=2fa449867d4c4b47b173ba846f6e1c33&elqaid=514&elqat=1&elqTrackId=b4d9a2a0f1424fe28f720ff9d8ae4d54)

This PR updates the urls as explained [here](http://www.authorize.net/support/akamaifaqs/?utm_campaign=May%202016%20Technical%20Updates%20for%20Merchants.html&utm_medium=email&utm_source=Eloqua&elqTrackId=08129a724d844ef09398ff1fedd30743&elq=2fa449867d4c4b47b173ba846f6e1c33&elqaid=514&elqat=1&elqCampaignId=353#newurls)
