### PR TITLE
stripe fix to ensure card object has object key

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -188,6 +188,8 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard(post, creditcard, options)
         card = {}
+        card[:object] = "card"
+
         if creditcard.respond_to?(:number)
           if creditcard.respond_to?(:track_data) && creditcard.track_data.present?
             card[:swipe_data] = creditcard.track_data


### PR DESCRIPTION
- fix for failing tokenizations
  - returning "The source hash must include an &#39;object&#39; key indicating what type of source to create." message 
  - failure introduced after changes in https://github.com/sellect/active_merchant/commit/00da6ed9e917d0630244f0b45fc5c6a906e8150b#diff-8299be227de5ba32c34c30c42a828c9cR202 (https://github.com/sellect/active_merchant/releases/tag/v1.40.0.12)
